### PR TITLE
Fix test on windows server

### DIFF
--- a/t/netadmin.t
+++ b/t/netadmin.t
@@ -21,7 +21,7 @@ use Win32::NetAdmin qw(:DEFAULT UserCreate UserDelete UserGetAttributes
 
 my $serverName   = '';
 my $userName     = 'TestUser';
-my $password     = 'password';
+my $password     = 'pa55w0r&';
 my $passwordAge  = 0;
 my $privilege    = USER_PRIV_USER;
 my $homeDir      = 'c:\\';

--- a/t/netadmin.t
+++ b/t/netadmin.t
@@ -35,12 +35,12 @@ plan tests => 15;
 
 ok(UserCreate($serverName, $userName, $password, $passwordAge, $privilege,
 	      $homeDir, $comment, $flags, $scriptpath))
-  or warn "Test encountered error: ".Win32::FormatMessage(Win32::NetAdmin::GetError()) ;
+  or warn "\nTest encountered error:\n\t".Win32::FormatMessage(Win32::NetAdmin::GetError()) ;
 
 ok(UserGetAttributes($serverName, $userName,
 		     my $Getpassword, my $GetpasswordAge, my $Getprivilege,
 		     my $GethomeDir, my $Getcomment, my $Getflags, my $Getscriptpath))
-  or warn "Test encountered error: ".Win32::FormatMessage(Win32::NetAdmin::GetError()) ;
+  or warn "\nTest encountered error:\n\t".Win32::FormatMessage(Win32::NetAdmin::GetError()) ;
 
 ok($passwordAge <= $GetpasswordAge && $passwordAge+5 >= $GetpasswordAge);
 
@@ -58,20 +58,20 @@ ok($flags == ($Getflags&USER_PRIV_MASK));
 ok($scriptpath, $Getscriptpath);
 
 ok(LocalGroupCreate($serverName, $groupName, $groupComment))
-  or warn "Test encountered error: ".Win32::FormatMessage(Win32::NetAdmin::GetError()) ;
+  or warn "\nTest encountered error:\n\t".Win32::FormatMessage(Win32::NetAdmin::GetError()) ;
 
 ok(LocalGroupGetAttributes($serverName, $groupName, my $GetgroupComment))
-  or warn "Test encountered error: ".Win32::FormatMessage(Win32::NetAdmin::GetError()) ;
+  or warn "\nTest encountered error:\n\t".Win32::FormatMessage(Win32::NetAdmin::GetError()) ;
 ok($groupComment, $GetgroupComment);
 
 ok(LocalGroupAddUsers($serverName, $groupName, $userName))
-  or warn "Test encountered error: ".Win32::FormatMessage(Win32::NetAdmin::GetError()) ;
+  or warn "\nTest encountered error:\n\t".Win32::FormatMessage(Win32::NetAdmin::GetError()) ;
 
 ok(LocalGroupIsMember($serverName, $groupName, $userName))
-  or warn "Test encountered error: ".Win32::FormatMessage(Win32::NetAdmin::GetError()) ;
+  or warn "\nTest encountered error:\n\t".Win32::FormatMessage(Win32::NetAdmin::GetError()) ;
 
 ok(LocalGroupDelete($serverName, $groupName))
-  or warn "Test encountered error: ".Win32::FormatMessage(Win32::NetAdmin::GetError()) ;
+  or warn "\nTest encountered error:\n\t".Win32::FormatMessage(Win32::NetAdmin::GetError()) ;
 
 ok(UserDelete($serverName, $userName))
-  or warn "Test encountered error: ".Win32::FormatMessage(Win32::NetAdmin::GetError()) ;
+  or warn "\nTest encountered error:\n\t".Win32::FormatMessage(Win32::NetAdmin::GetError()) ;

--- a/t/netadmin.t
+++ b/t/netadmin.t
@@ -34,11 +34,13 @@ my $groupComment = "This is a test group";
 plan tests => 15;
 
 ok(UserCreate($serverName, $userName, $password, $passwordAge, $privilege,
-	      $homeDir, $comment, $flags, $scriptpath));
+	      $homeDir, $comment, $flags, $scriptpath))
+  or warn "Test encountered error: ".Win32::FormatMessage(Win32::NetAdmin::GetError()) ;
 
 ok(UserGetAttributes($serverName, $userName,
 		     my $Getpassword, my $GetpasswordAge, my $Getprivilege,
-		     my $GethomeDir, my $Getcomment, my $Getflags, my $Getscriptpath));
+		     my $GethomeDir, my $Getcomment, my $Getflags, my $Getscriptpath))
+  or warn "Test encountered error: ".Win32::FormatMessage(Win32::NetAdmin::GetError()) ;
 
 ok($passwordAge <= $GetpasswordAge && $passwordAge+5 >= $GetpasswordAge);
 
@@ -55,15 +57,21 @@ ok($comment, $Getcomment);
 ok($flags == ($Getflags&USER_PRIV_MASK));
 ok($scriptpath, $Getscriptpath);
 
-ok(LocalGroupCreate($serverName, $groupName, $groupComment));
+ok(LocalGroupCreate($serverName, $groupName, $groupComment))
+  or warn "Test encountered error: ".Win32::FormatMessage(Win32::NetAdmin::GetError()) ;
 
-ok(LocalGroupGetAttributes($serverName, $groupName, my $GetgroupComment));
+ok(LocalGroupGetAttributes($serverName, $groupName, my $GetgroupComment))
+  or warn "Test encountered error: ".Win32::FormatMessage(Win32::NetAdmin::GetError()) ;
 ok($groupComment, $GetgroupComment);
 
-ok(LocalGroupAddUsers($serverName, $groupName, $userName));
+ok(LocalGroupAddUsers($serverName, $groupName, $userName))
+  or warn "Test encountered error: ".Win32::FormatMessage(Win32::NetAdmin::GetError()) ;
 
-ok(LocalGroupIsMember($serverName, $groupName, $userName));
+ok(LocalGroupIsMember($serverName, $groupName, $userName))
+  or warn "Test encountered error: ".Win32::FormatMessage(Win32::NetAdmin::GetError()) ;
 
-ok(LocalGroupDelete($serverName, $groupName));
+ok(LocalGroupDelete($serverName, $groupName))
+  or warn "Test encountered error: ".Win32::FormatMessage(Win32::NetAdmin::GetError()) ;
 
-ok(UserDelete($serverName, $userName));
+ok(UserDelete($serverName, $userName))
+  or warn "Test encountered error: ".Win32::FormatMessage(Win32::NetAdmin::GetError()) ;


### PR DESCRIPTION
added more verbose messages in case of test failure, regarding the underlying error.
As the test now fails obviously due to password too weak,
password changed to meet default password policies.

Fixes: https://rt.cpan.org/Ticket/Display.html?id=127508