### PR TITLE
Move to perl-libwin32 org

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,17 @@
+name: release
+
+on:
+  push:
+    tags: ['v*']
+
+jobs:
+  release:
+    runs-on: windows-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: perl-libwin32/.github/release-action@v1
+        with:
+          version-file: NetAdmin.pm
+          dist-name: Win32-NetAdmin

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,11 @@
+name: test
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    uses: perl-libwin32/.github/.github/workflows/test.yml@v1

--- a/META.yml
+++ b/META.yml
@@ -3,13 +3,14 @@ name: Win32-NetAdmin
 abstract: Manage network groups and users in Perl
 version: 0.13
 author:
-  - Jan Dubois <jand@activestate.com>
+  - Jan Dubois <jan@jandubois.com>
 license: perl
 requires: 
   perl: 5.006
 resources:
   license: http://dev.perl.org/licenses/
-  repository: https://github.com/jandubois/win32-netadmin
+  repository: https://github.com/perl-libwin32/win32-netadmin
+  bugtracker: https://github.com/perl-libwin32/win32-netadmin/issues
 meta-spec:
    version: 1.3
    url: http://module-build.sourceforge.net/META-spec-v1.3.html


### PR DESCRIPTION
Wire up the org-shared workflows and update metadata for the perl-libwin32 move.

- Add `.github/workflows/test.yml` calling `perl-libwin32/.github/.github/workflows/test.yml@v1`.
- Add `.github/workflows/release.yml` calling `perl-libwin32/.github/release-action@v1`.
- Update `META.yml` repository URL and add bugtracker.
- Canonicalise author email to `jan@jandubois.com`.

The validator in `perl-libwin32/.github` requires these for the next release.