### PR TITLE
Fix Cygwin g++ build of Net*Enum resumehandle calls

### DIFF
--- a/NetAdmin.xs
+++ b/NetAdmin.xs
@@ -2173,7 +2173,11 @@ XS(XS_NT__NetAdmin_GetUserGroupFromRID)
     RETURNRESULT(bSuccess);
 }
 
-XS(boot_Win32__NetAdmin)
+/* Force C linkage on the boot symbol so XSLoader/DynaLoader can find
+ * it by its unmangled name when the file is compiled as C++ (e.g.,
+ * Cygwin g++). The XS() macro alone does not declare extern "C".
+ */
+EXTERN_C XS(boot_Win32__NetAdmin)
 {
     dXSARGS;
     char* file = __FILE__;

--- a/NetAdmin.xs
+++ b/NetAdmin.xs
@@ -58,6 +58,23 @@
 
 #define PREFLEN 0x20000
 
+/* Cygwin's <lmaccess.h> and <lmwksta.h> declare the resumehandle
+ * parameter of NetUserEnum, NetWkstaTransportEnum, NetWkstaUserEnum,
+ * NetServerEnum, and NetServerDiskEnum as LPDWORD, while MSDN and the
+ * Windows SDK use PDWORD or PDWORD_PTR. The underlying netapi32.dll
+ * on x64 still writes a pointer-sized value through the argument, so
+ * DWORD_PTR storage is required to avoid stack corruption; we only
+ * cast the address to match Cygwin's narrower signature. gcc accepts
+ * the conversion with a warning; g++ rejects it. NetGroupGetUsers and
+ * NetLocalGroupGetMembers declare the parameter as PDWORD_PTR even on
+ * Cygwin and need no cast.
+ */
+#ifdef __CYGWIN__
+#  define CYG_RESUME_HANDLE(h) ((LPDWORD)&(h))
+#else
+#  define CYG_RESUME_HANDLE(h) (&(h))
+#endif
+
 /* constant function for exporting NT definitions. */
 
 static long
@@ -972,7 +989,7 @@ XS(XS_NT__NetAdmin_GetUsers)
 		lastError = NetUserEnum(lpwServer, 0, filter,
 					(LPBYTE*)&pwzUsers, PREFLEN,
 					&entriesRead, &totalEntries,
-					&resumeHandle);
+					CYG_RESUME_HANDLE(resumeHandle));
 		if (lastError != 0 && lastError != ERROR_MORE_DATA)
 		    break;
 		for (index = 0; index < entriesRead; ++index) {
@@ -990,7 +1007,7 @@ XS(XS_NT__NetAdmin_GetUsers)
 		lastError = NetUserEnum(lpwServer,10, filter,
 					(LPBYTE*)&pwzUsers10, PREFLEN,
 					&entriesRead, &totalEntries,
-					&resumeHandle);
+					CYG_RESUME_HANDLE(resumeHandle));
 		if (lastError != 0 && lastError != ERROR_MORE_DATA)
 		    break;
 		for (index = 0; index < entriesRead; ++index) {
@@ -1043,7 +1060,7 @@ XS(XS_NT__NetAdmin_GetTransports)
 		lastError = NetWkstaTransportEnum(lpwServer, 0,
 					  (LPBYTE*) &pws,
 					  PREFLEN, &entriesRead,
-					  &totalEntries, &resumeHandle);
+					  &totalEntries, CYG_RESUME_HANDLE(resumeHandle));
 		if (lastError != 0 && lastError != ERROR_MORE_DATA)
 		    break;
 		for (index = 0; index < entriesRead; ++index) {
@@ -1062,7 +1079,7 @@ XS(XS_NT__NetAdmin_GetTransports)
 		lastError = NetWkstaTransportEnum(lpwServer, 0,
 						  (LPBYTE*) &pws,
 						  PREFLEN, &entriesRead,
-						  &totalEntries, &resumeHandle);
+						  &totalEntries, CYG_RESUME_HANDLE(resumeHandle));
 		if (lastError != 0 && lastError != ERROR_MORE_DATA)
 		    break;
 		for (index = 0; index < entriesRead; ++index) {
@@ -1136,7 +1153,7 @@ XS(XS_NT__NetAdmin_LoggedOnUsers)
 		lastError = NetWkstaUserEnum(lpwServer, 0,
 					(LPBYTE*)&pwzUser0, PREFLEN,
 					&entriesRead, &totalEntries,
-					&resumeHandle);
+					CYG_RESUME_HANDLE(resumeHandle));
 		if (lastError != 0 && lastError != ERROR_MORE_DATA)
 		    break;
 		for (index = 0; index < entriesRead; ++index) {
@@ -1154,7 +1171,7 @@ XS(XS_NT__NetAdmin_LoggedOnUsers)
 		lastError = NetWkstaUserEnum(lpwServer,1,
 					     (LPBYTE*)&pwzUser1, PREFLEN,
 					     &entriesRead, &totalEntries,
-					     &resumeHandle);
+					     CYG_RESUME_HANDLE(resumeHandle));
 		if (lastError != 0 && lastError != ERROR_MORE_DATA)
 		    break;
 		for (index = 0; index < entriesRead; ++index) {
@@ -1929,7 +1946,7 @@ XS(XS_NT__NetAdmin_GetServers)
 					  (LPBYTE*) &pwzServerInfo,
 					  PREFLEN, &entriesRead,
 					  &totalEntries, (DWORD)SvIV(ST(2)),
-					  lpwDomain, &resumeHandle);
+					  lpwDomain, CYG_RESUME_HANDLE(resumeHandle));
 		if (lastError != 0 && lastError != ERROR_MORE_DATA)
 		    break;
 		for (index = 0; index < entriesRead; ++index) {
@@ -1951,7 +1968,7 @@ XS(XS_NT__NetAdmin_GetServers)
 					  (LPBYTE*) &pwzServerInfo101,
 					  PREFLEN, &entriesRead,
 					  &totalEntries, (DWORD)SvIV(ST(2)),
-					  lpwDomain, &resumeHandle);
+					  lpwDomain, CYG_RESUME_HANDLE(resumeHandle));
 		if (lastError != 0 && lastError != ERROR_MORE_DATA)
 		    break;
 		for (index = 0; index < entriesRead; ++index) {
@@ -2006,7 +2023,7 @@ XS(XS_NT__NetAdmin_GetServerDisks)
 						    (LPBYTE*)&disks,
 						    PREFLEN, &entriesRead,
 						    &totalEntries,
-						    &resumeHandle);
+						    CYG_RESUME_HANDLE(resumeHandle));
 		if (lastError != 0 && lastError != ERROR_MORE_DATA)
 		    break;
 		p = disks;


### PR DESCRIPTION
Closes #11.

Cygwin's `<lmaccess.h>` and `<lmwksta.h>` declare the `resumehandle`
parameter of `NetUserEnum`, `NetWkstaTransportEnum`, `NetWkstaUserEnum`,
`NetServerEnum`, and `NetServerDiskEnum` as `LPDWORD`, while MSDN and
the Windows SDK use `PDWORD` or `PDWORD_PTR`. The underlying
`netapi32.dll` on x64 still writes a pointer-sized value, so `DWORD_PTR`
storage is required to avoid stack corruption; only the call-site
pointer type needs to match Cygwin's narrower header.

`gcc` accepts the implicit `DWORD_PTR*` → `LPDWORD` conversion with a
warning, but `g++` rejects it as a hard error.

## Approach

Add a `CYG_RESUME_HANDLE()` macro that casts the address on Cygwin and
expands to a plain `&` elsewhere. Apply it at the nine call sites that
Cygwin's headers mis-declare; leave the six `NetGroupGetUsers` and
`NetLocalGroupGetMembers` sites alone (Cygwin matches MSDN there, and a
blanket cast would break those).

## What this does not do

- Does not narrow `resumeHandle` storage from `DWORD_PTR` to `DWORD`
  (which would corrupt the stack on x64).
- Does not skip the Cygwin g++ matrix entry.
- Does not affect the generated code on Strawberry, MinGW, or Cygwin gcc
  (the `#else` branch is byte-identical to the prior `&resumeHandle`).

## References

- [NetUserEnum (lmaccess.h)](https://learn.microsoft.com/en-us/windows/win32/api/lmaccess/nf-lmaccess-netuserenum) — MSDN says `PDWORD`
- [NetLocalGroupEnum (lmaccess.h)](https://learn.microsoft.com/en-us/windows/win32/api/lmaccess/nf-lmaccess-netlocalgroupenum) — MSDN says `PDWORD_PTR`
- [tpn/winsdk-10 LMaccess.h](https://github.com/tpn/winsdk-10/blob/master/Include/10.0.14393.0/um/LMaccess.h) — Windows SDK reference
- [mingw-w64 lmaccess.h](https://github.com/msys2-contrib/mingw-w64/blob/master/mingw-w64-headers/include/lmaccess.h) — uses `PDWORD_PTR`, matches MSDN