### PR TITLE
Restore early-exit and tab indentation in LocalGroupIsMember loop

### DIFF
--- a/NetAdmin.xs
+++ b/NetAdmin.xs
@@ -1731,30 +1731,25 @@ XS(XS_NT__NetAdmin_LocalGroupIsMember)
 	AllocWideName((char*)SvPV(ST(0),n_a), lpwServer);
 	AllocWideName((char*)SvPV(ST(1),n_a), lpwGroup);
 	do {
-	    PLOCALGROUP_MEMBERS_INFO_0 pwzMembersInfo;
-	    pwzMembersInfo = NULL;
+	    PLOCALGROUP_MEMBERS_INFO_0 pwzMembersInfo = NULL;
 	    lastError = NetLocalGroupGetMembers(lpwServer, lpwGroup, 0,
 						(LPBYTE*)&pwzMembersInfo,
 		    				PREFLEN, &entriesRead,
 						&totalEntries, &resumeHandle);
 	    if (lastError != 0 && lastError != ERROR_MORE_DATA) {
-	        if (pwzMembersInfo != NULL) {
+		if (pwzMembersInfo != NULL)
 		    NetApiBufferFree(pwzMembersInfo);
-	        }
 		break;
 	    }
-
-            if (bReturn == FALSE) {
-                for (index = 0; index < entriesRead; ++index) {
-                    if (EqualSid(pSid, pwzMembersInfo[index].lgrmi0_sid) != 0){
-		      bReturn = TRUE;
-		      break;
-		    }
-	        }
-	    }
+	    for (index = 0; index < entriesRead; ++index)
+		if (EqualSid(pSid, pwzMembersInfo[index].lgrmi0_sid) != 0) {
+		    bReturn = TRUE;
+		    break;
+		}
 
 	    NetApiBufferFree(pwzMembersInfo);
-	} while(lastError == ERROR_MORE_DATA || resumeHandle != 0);
+	} while(bReturn == FALSE &&
+		(lastError == ERROR_MORE_DATA || resumeHandle != 0));
 
 	free(pSid);
 	FreeWideName(lpwServer);


### PR DESCRIPTION
## Summary

Follow-up to #8. The leak fix there also dropped `bReturn == FALSE` from the do-while guard, so a positive match keeps paging through every remaining batch of group members before returning. This restores the short-circuit (matching the sibling `GroupIsMember` loop at line 1432), drops the now-redundant inner `if (bReturn == FALSE)` wrapper, and re-indents the new lines with tabs to match the rest of the file. `pwzMembersInfo = NULL` is folded into the declaration.

The error-path leak fix from #8 is preserved.

## Test plan

- [ ] CI green on Strawberry 5.32 / 5.38 / 5.40
- [ ] Visual diff confirms only formatting and the loop guard change